### PR TITLE
Excluding base url prefix to cdn thumbnails

### DIFF
--- a/build/lib/py1337x/__init__.py
+++ b/build/lib/py1337x/__init__.py
@@ -1,0 +1,1 @@
+from py1337x.py1337x import py1337x

--- a/build/lib/py1337x/parser.py
+++ b/build/lib/py1337x/parser.py
@@ -74,7 +74,7 @@ def infoParser(response, baseUrl):
     thumbnail = soup.find('div', {'class': 'torrent-image'})
     thumbnail = thumbnail.find('img')['src'] if thumbnail else None
 
-    if thumbnail and not (thumbnail.startswith('http') or thumbnail.startswith("//")):
+    if thumbnail and not thumbnail.startswith('http'):
         thumbnail = f'{baseUrl}'+thumbnail
 
     magnetLink = soup.select('a[href^="magnet"]')

--- a/build/lib/py1337x/py1337x.py
+++ b/build/lib/py1337x/py1337x.py
@@ -1,0 +1,71 @@
+import requests
+import requests_cache
+from py1337x import parser
+
+
+class py1337x():
+    def __init__(self, proxy=None, cookie=None, cache=None, cacheTime=86400, backend='sqlite'):
+        self.baseUrl = f'https://www.{proxy}' if proxy else 'https://www.1377x.to'
+        self.headers = {
+            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:88.0) Gecko/20100101 Firefox/88.0',
+            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'accept-language': 'en-US,en;q=0.5',
+            'upgrade-insecure-requests': '1',
+            'te': 'trailers'
+        }
+
+        if cookie:
+            self.headers['cookie'] = f'cf_clearance={cookie}'
+
+        self.requests = requests_cache.CachedSession(cache, expire_after=cacheTime, backend=backend) if cache else requests
+
+    #: Searching torrents
+    def search(self, query, page=1, category=None, sortBy=None, order='desc'):
+        query = '+'.join(query.split())
+        category = category.upper() if category and category.lower() in ['xxx', 'tv'] else category.capitalize() if category else None
+        url = f"{self.baseUrl}/{'sort-' if sortBy else ''}{'category-' if category else ''}search/{query}/{category+'/' if category else ''}{sortBy.lower()+'/' if sortBy else ''}{order.lower()+'/' if sortBy else ''}{page}/"
+
+        response = self.requests.get(url, headers=self.headers)
+        return parser.torrentParser(response, baseUrl=self.baseUrl, page=page)
+
+    #: Trending torrents
+    def trending(self, category=None, week=False):
+        url = f"{self.baseUrl}/trending{'-week' if week and not category else ''}{'/w/'+category.lower()+'/' if week and category else '/d/'+category.lower()+'/' if not week and category else ''}"
+
+        response = self.requests.get(url, headers=self.headers)
+        return parser.torrentParser(response, baseUrl=self.baseUrl)
+
+    #: Top 100 torrents
+    def top(self, category=None):
+        category = 'applications' if category and category.lower() == 'apps' else 'television' if category and category.lower() == 'tv' else category.lower() if category else None
+        url = f"{self.baseUrl}/top-100{'-'+category if category else ''}"
+
+        response = self.requests.get(url, headers=self.headers)
+        return parser.torrentParser(response, baseUrl=self.baseUrl)
+
+    #: Popular torrents
+    def popular(self, category, week=False):
+        url = f"{self.baseUrl}/popular-{category.lower()}{'-week' if week else ''}"
+
+        response = self.requests.get(url, headers=self.headers)
+        return parser.torrentParser(response, baseUrl=self.baseUrl)
+
+    #: Browse torrents by category type
+    def browse(self, category, page=1):
+        category = category.upper() if category.lower() in ['xxx', 'tv'] else category.capitalize()
+        url = f'{self.baseUrl}/cat/{category}/{page}/'
+
+        response = self.requests.get(url, headers=self.headers)
+        return parser.torrentParser(response, baseUrl=self.baseUrl, page=page)
+
+    #: Info of torrent
+    def info(self, link=None, torrentId=None):
+        if not link and not torrentId:
+            raise TypeError('Missing 1 required positional argument: link or torrentId')
+        elif link and torrentId:
+            raise TypeError('Got an unexpected argument: Pass either link or torrentId')
+
+        link = f'{self.baseUrl}/torrent/{torrentId}/h9/' if torrentId else link
+        response = self.requests.get(link, headers=self.headers)
+
+        return parser.infoParser(response, baseUrl=self.baseUrl)


### PR DESCRIPTION
**Before:**
The 'base-URL' will be the prefix of the thumbnail's URL if it does not start with "HTTP".

**Issue**
Many thumbnails are served from CDNs (URLs starting with "//") and thus will not require "1337x.to" as the base URL.

**Fix**
URLs starting with "HTTP" and "//" i.e CDN URLs will be discarded from any base URL addition process.

_Sample URL:_ https://1337x.to/torrent/5464180/Black-Adam-2022-FullHD-1080p-H264-Ita-Eng-AC3-5-1-Sub-Ita-Eng-realDMDJ-DDL_Ita/